### PR TITLE
Fix potential word-splitting issues

### DIFF
--- a/makepkg-source.sh
+++ b/makepkg-source.sh
@@ -11,6 +11,6 @@ for dir in ./asp/*; do
 	cd "$startdir/$dir"
 	SRCDEST="${sourcedest_path}" BUILDDIR=. makepkg --nobuild --nodeps --noprepare --skippgpcheck --skipinteg
 	d=$(find src/ -maxdepth 1 ! -path src/ -type d)
-	mkdir -p $source_path/$(basename $dir)
-	mv $d $source_path/$(basename $dir)
+	mkdir -p "$source_path/$(basename $dir)"
+	mv "$d" "$source_path/$(basename $dir)"
 done


### PR DESCRIPTION
`readlink -f` returns the fully-qualified path to `$PWD/source` and `$PWD/sourcedest` - `$PWD` may be a path containing spaces, thus all references to `$source_path` and `$sourcedest_path` need to be quoted